### PR TITLE
fix type error on domainSearch method

### DIFF
--- a/src/Tomba/Client.php
+++ b/src/Tomba/Client.php
@@ -33,7 +33,7 @@ class Client
      *
      * @var array
      */
-    protected $headers = [
+    public $headers = [
         'content-type' => '',
         'x-sdk-version' => 'tomba:php:v1.0.0',
     ];
@@ -107,7 +107,7 @@ class Client
     public function addHeader($key, $value)
     {
         $this->headers[strtolower($key)] = $value;
-        
+
         return $this;
     }
 

--- a/src/Tomba/Client.php
+++ b/src/Tomba/Client.php
@@ -33,7 +33,7 @@ class Client
      *
      * @var array
      */
-    public $headers = [
+    protected $headers = [
         'content-type' => '',
         'x-sdk-version' => 'tomba:php:v1.0.0',
     ];

--- a/src/Tomba/Services/Domain.php
+++ b/src/Tomba/Services/Domain.php
@@ -21,9 +21,9 @@ class Domain extends Service
      * @param int $limit
      * @param string $department
      * @throws TombaException
-     * @return array
+     * @return array|string
      */
-    public function domainSearch(string $domain, int $page = null, int $limit = null, string $department = null): array
+    public function domainSearch(string $domain, int $page = null, int $limit = null, string $department = null): array | string
     {
         if (!isset($domain)) {
             throw new TombaException('Missing required parameter: "domain"');


### PR DESCRIPTION
Added a string return type on the domainSearch method to ensure no errors are thrown when it returns a string containing a json object.

Closes #1 